### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,26 @@
 # The directory Mix will write compiled artifacts to.
-/_build
+/_build/
 
 # If you run "mix test --cover", coverage assets end up here.
-/cover
+/cover/
 
 # The directory Mix downloads your dependencies sources to.
-/deps
+/deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
-/doc
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
 
 # If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+sneeze-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The MIT License (MIT)
+# The MIT License (MIT)
 
 Copyright (c) 2016 Shane Kilkelly
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Sneeze
 
-Render Elixir data-structures to HTML. Inspired by [Hiccup](https://github.com/weavejester/hiccup).
-
 [![CircleCI](https://circleci.com/gh/ShaneKilkelly/sneeze.svg?style=shield)](https://circleci.com/gh/ShaneKilkelly/sneeze)
+[![Module Version](https://img.shields.io/hexpm/v/sneeze.svg)](https://hex.pm/packages/sneeze)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/sneeze/)
+[![Total Download](https://img.shields.io/hexpm/dt/sneeze.svg)](https://hex.pm/packages/sneeze)
+[![License](https://img.shields.io/hexpm/l/sneeze.svg)](https://github.com/JuneKelly/sneeze/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/JuneKelly/sneeze.svg)](https://github.com/JuneKelly/sneeze/commits/master)
+
+Render Elixir data-structures to HTML. Inspired by [Hiccup](https://github.com/weavejester/hiccup).
 
 
 ## Installation
@@ -11,7 +16,9 @@ Sneeze is available from [Hex.pm](https://hex.pm/packages/sneeze):
 
 ```elixir
 def deps do
-  [{:sneeze, "~> 1.2"}]
+  [
+    {:sneeze, "~> 1.2"}
+  ]
 end
 ```
 
@@ -95,3 +102,11 @@ Open an issue or pull-request on [GitHub](https://github.com/ShaneKilkelly/sneez
 ### 1.1.0
 
 - Better performance, using iolists instead of string-concatination
+
+
+## Copyright and License
+
+Copyright (c) 2016 Shane Kilkelly
+
+This work is free. You can redistribute it and/or modify it under the
+terms of the MIT License. See the [LICENSE.md](./LICENSE.md) file for more details.

--- a/lib/sneeze.ex
+++ b/lib/sneeze.ex
@@ -16,20 +16,22 @@ defmodule Sneeze do
   - A bare, stringable value (such as a string or number)
   - A list of elements
 
-  The content of `:__@raw_html`, `:style` and `:script` elements will not be escaped.
+  The content of `:__@raw_html`, `:style` and `:script` elements will not be
+  escaped.
+
   All other elements content will be html-escaped.
 
-  Examples:
-  ```
-  render([:p, %{class: "outlined"}, "hello"])
-  render([:br])
-  render([[:span, "one"], [:span, %{class: "highlight"}, "two"]])
-  render([:ul, %{id: "some-list"},
-          [:li, [:a, %{href: "/"},      "Home"]],
-          [:li, [:a, %{href: "/about"}, "About"]]])
-  render([:__@raw_html, "<!DOCTYPE html>"])
-  render([:script, "console.log(42 < 9);"])
-  ```
+  ## Examples
+
+      render([:p, %{class: "outlined"}, "hello"])
+      render([:br])
+      render([[:span, "one"], [:span, %{class: "highlight"}, "two"]])
+      render([:ul, %{id: "some-list"},
+              [:li, [:a, %{href: "/"},      "Home"]],
+              [:li, [:a, %{href: "/about"}, "About"]]])
+      render([:__@raw_html, "<!DOCTYPE html>"])
+      render([:script, "console.log(42 < 9);"])
+
   """
   def render(data) do
     # _render(data)

--- a/mix.exs
+++ b/mix.exs
@@ -1,48 +1,53 @@
 defmodule Sneeze.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/ShaneKilkelly/sneeze"
+  @version "1.2.0"
+
   def project do
     [
       app: :sneeze,
-      version: "1.2.0",
+      version: @version,
       elixir: "~> 1.6",
-      description: "Render Elixir data to HTML. Inspired by Hiccup.",
       package: package(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      docs: docs()
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
   def application do
     [applications: [:html_entities]]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
   defp deps do
     [
       {:html_entities, "0.4.0"},
-      {:ex_doc, ">= 0.14.1", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end
 
   defp package do
     [
+      description: "Render Elixir data to HTML. Inspired by Hiccup.",
       name: :sneeze,
       maintainers: ["Shane Kilkelly"],
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/ShaneKilkelly/sneeze"}
+    ]
+  end
+
+  defp docs do
+    [
+      extras: [
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      formatters: ["html"]
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,12 @@
 %{
-  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.14.1", "bfed8d4e93c755e2b150be925ad2cfa6af7c3bfcacc3b609f45f6048c9d623d6", [:mix], [{:earmark, "~> 1.0", [repo: "hexpm", hex: :earmark, optional: false]}], "hexpm"},
-  "html_entities": {:hex, :html_entities, "0.4.0", "f2fee876858cf6aaa9db608820a3209e45a087c5177332799592142b50e89a6b", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], [], "hexpm", "db7b13d74a9edc54d3681762154d164d4a661cd27673cca80760344449877664"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.15", "b29e8e729f4aa4a00436580dcc2c9c5c51890613457c193cc8525c388ccb2f06", [:mix], [], "hexpm", "044523d6438ea19c1b8ec877ec221b008661d3c27e3b848f4c879f500421ca5c"},
+  "ex_doc": {:hex, :ex_doc, "0.25.1", "4b736fa38dc76488a937e5ef2944f5474f3eff921de771b25371345a8dc810bc", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "3200b0a69ddb2028365281fbef3753ea9e728683863d8cdaa96580925c891f67"},
+  "html_entities": {:hex, :html_entities, "0.4.0", "f2fee876858cf6aaa9db608820a3209e45a087c5177332799592142b50e89a6b", [:mix], [], "hexpm", "3e3d7156a272950373ce5a4018b1490bea26676f8d6a7d409f6fac8568b8cb9a"},
   "html_sanitize_ex": {:hex, :html_sanitize_ex, "1.0.1", "2572e7122c78ab7e57b613e7c7f5e42bf9b3c25e430e32f23f1413d86db8a0af", [:mix], [{:mochiweb, "~> 2.12.2", [hex: :mochiweb, optional: false]}]},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
+  "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "mochiweb": {:hex, :mochiweb, "2.12.2", "80804ad342afa3d7f3524040d4eed66ce74b17a555de454ac85b07c479928e46", [:make, :rebar], []},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
 }


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.