### PR TITLE
Add a `Sneeze.render_iodata/1` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The `Sneeze.render/1` function will render a list of 'nodes' to html. A node can
 Of course, the `body` of any node can be an arbitrary number of other nodes, like so:
 `[:p, %{id: "status"}, [:span, "woo"]]`
 
+The `Sneeze.render_iodata/1` function returns an iodata list, which can be more performant in cases where you are passing the result to a function that accepts iodata.
+
 
 ## Examples
 
@@ -63,6 +65,13 @@ Sneeze.render([
    [:div, %{id: "main-content"}, "hello"]]
 ]
 # => <!DOCTYPE html><head><title>wat</title></head><body><div id="main-content">hello</div></body>
+
+Sneeze.render_iodata([:a, %{href: "example.com"}, "hello"])
+# => [
+#      ["<", "a", [[" ", "href", "=\"", "example.com", "\""]], ">"],
+#      [["hello"]],
+#      ["</", "a", ">"]
+#    ]
 ```
 
 If you're using sneeze and getting surprising/screwy results, please [open an issue](https://github.com/JuneKelly/sneeze/issues).

--- a/lib/sneeze.ex
+++ b/lib/sneeze.ex
@@ -32,8 +32,26 @@ defmodule Sneeze do
   ```
   """
   def render(data) do
-    # _render(data)
     IO.iodata_to_binary(_render(data))
+  end
+
+  @doc ~s"""
+  Render a data-structure, containing 'elements' to an iodata list.
+  This can be more performant than `render/1` if you are passing the result to a function that takes iodata.
+
+  Example:
+  ```
+  render_iodata([:a, %{href: "example.com"}, "hello"])
+  # becomes...
+  [
+    ["<", "a", [[" ", "href", "=\"", "example.com", "\""]], ">"],
+    [["hello"]],
+    ["</", "a", ">"]
+  ]
+  ```
+  """
+  def render_iodata(data) do
+    _render(data)
   end
 
   defp _render(data) do

--- a/test/sneeze_test.exs
+++ b/test/sneeze_test.exs
@@ -18,8 +18,9 @@ defmodule SneezeTest do
     assert Sneeze.render(42) == "42"
   end
 
-  test "empty" do
+  test "empty data" do
     assert Sneeze.render([]) == ""
+    assert Sneeze.render(nil) == ""
   end
 
   test "empty p tag" do

--- a/test/sneeze_test.exs
+++ b/test/sneeze_test.exs
@@ -113,6 +113,68 @@ defmodule SneezeTest do
     data = [:span, %{class: "lol 🐜"}, "Hello ◊"]
     assert Sneeze.render(data) == "<span class=\"lol 🐜\">Hello ◊</span>"
   end
+
+  test "render_iodata, empty data" do
+    assert Sneeze.render_iodata([]) == []
+    assert Sneeze.render_iodata(nil) == [""]
+  end
+
+  test "render_iodata, small example" do
+    data = [:a, %{href: "example.com"}, "hello"]
+
+    assert Sneeze.render_iodata(data) == [
+             ["<", "a", [[" ", "href", "=\"", "example.com", "\""]], ">"],
+             [["hello"]],
+             ["</", "a", ">"]
+           ]
+  end
+
+  test "render_iodata, larger example" do
+    data = [
+      :div,
+      [
+        [:span, %{class: "something"}, "hello"],
+        [:a, %{href: "example.com"}, "a link"]
+      ]
+    ]
+
+    assert Sneeze.render_iodata(data) == [
+             ["<", "div", ">"],
+             [
+               [
+                 [
+                   ["<", "span", [[" ", "class", "=\"", "something", "\""]], ">"],
+                   [["hello"]],
+                   ["</", "span", ">"]
+                 ],
+                 [
+                   [
+                     ["<", "a", [[" ", "href", "=\"", "example.com", "\""]], ">"],
+                     [["a link"]],
+                     ["</", "a", ">"]
+                   ]
+                 ]
+               ]
+             ],
+             ["</", "div", ">"]
+           ]
+  end
+
+  test "render_iodata, with embedded html" do
+    data = [
+      :p,
+      %{id: "wat"},
+      [:br],
+      [:__@raw_html, "<span>test</span>"],
+      [:br]
+    ]
+
+    assert Sneeze.render_iodata(data) == [
+             ["<", "p", [[" ", "id", "=\"", "wat", "\""]], ">"],
+             [[["<", "br", " />"]], ["<span>test</span>"], [["<", "br", " />"]]],
+             ["</", "p", ">"]
+           ]
+  end
 end
 
 defmodule SneezeInternalTest do


### PR DESCRIPTION
Closes https://github.com/JuneKelly/sneeze/issues/4

Adds a `render_iodata/1` function, useful (and more performant) when the result will be passed to a function that accepts iodata anyway.

Example:

```elixir
Sneeze.render_iodata([:a, %{href: "example.com"}, "hello"])
# => [
#      ["<", "a", [[" ", "href", "=\"", "example.com", "\""]], ">"],
#      [["hello"]],
#      ["</", "a", ">"]
#    ]

```