### PR TITLE
Sort attributes, to maintain stable order

### DIFF
--- a/lib/sneeze/internals.ex
+++ b/lib/sneeze/internals.ex
@@ -25,7 +25,8 @@ defmodule Sneeze.Internal do
   end
 
   def attributes_to_iolist(attrib_map) do
-    Enum.map(attrib_map, fn {k, v} -> [" ", to_string(k), "=\"", v, "\""] end)
+    Enum.sort(attrib_map)
+    |> Enum.map(fn {k, v} -> [" ", to_string(k), "=\"", v, "\""] end)
   end
 
   def render_opening_tag(tag_name) do

--- a/test/sneeze_test.exs
+++ b/test/sneeze_test.exs
@@ -184,8 +184,16 @@ defmodule SneezeInternalTest do
   alias Sneeze.Internal
 
   test "create attribute string from map" do
-    assert Internal.attributes_to_iolist(%{class: "foo", id: "bar"}) ==
+    assert Internal.attributes_to_iolist(%{id: "bar", class: "foo"}) ==
              [[" ", "class", "=\"", "foo", "\""], [" ", "id", "=\"", "bar", "\""]]
+  end
+
+  test "stable order of attributes, regardless of map key order" do
+    assert Internal.attributes_to_iolist(%{c: "3", b: "2", a: "1"}) == [
+             [" ", "a", "=\"", "1", "\""],
+             [" ", "b", "=\"", "2", "\""],
+             [" ", "c", "=\"", "3", "\""]
+           ]
   end
 
   test "empty attributes" do


### PR DESCRIPTION
Sort the attribute map before rendering, to ensure a predictable order of attributes in the resulting string.

This should solve https://github.com/JuneKelly/sneeze/issues/17