### PR TITLE
precompute tag to_string variants

### DIFF
--- a/lib/sneeze/internals.ex
+++ b/lib/sneeze/internals.ex
@@ -1,4 +1,33 @@
 defmodule Sneeze.Internal do
+  require Sneeze.Macros
+
+  Sneeze.Macros.define_tags_to_strings([
+    :a,
+    :span,
+    :li,
+    :div,
+    :td,
+    :br,
+    :ul,
+    :tr,
+    :link,
+    :p,
+    :title,
+    :script,
+    :style,
+    :button,
+    :label,
+    :code,
+    :h1,
+    :h2,
+    :h3,
+    :h4,
+    :h5,
+    :meta,
+    :body,
+    :head
+  ])
+
   def void_tags() do
     [
       :area,
@@ -29,25 +58,25 @@ defmodule Sneeze.Internal do
   end
 
   def render_opening_tag(tag_name) do
-    ["<", to_string(tag_name), ">"]
+    ["<", tag_to_string(tag_name), ">"]
   end
 
   def render_opening_tag(tag_name, attribs) do
     attrib_iolist = attributes_to_iolist(attribs)
-    ["<", to_string(tag_name), attrib_iolist, ">"]
+    ["<", tag_to_string(tag_name), attrib_iolist, ">"]
   end
 
   def render_closing_tag(tag_name) do
-    ["</", to_string(tag_name), ">"]
+    ["</", tag_to_string(tag_name), ">"]
   end
 
   def render_void_tag(tag_name) do
-    ["<", to_string(tag_name), " />"]
+    ["<", tag_to_string(tag_name), " />"]
   end
 
   def render_void_tag(tag_name, attribs) do
     attrib_iolist = attributes_to_iolist(attribs)
-    ["<", to_string(tag_name), attrib_iolist, " ", "/>"]
+    ["<", tag_to_string(tag_name), attrib_iolist, " ", "/>"]
   end
 
   def render_tag(tag) do
@@ -57,4 +86,5 @@ defmodule Sneeze.Internal do
   def render_tag(tag, attributes) do
     [render_opening_tag(tag, attributes), render_closing_tag(tag)]
   end
+
 end

--- a/lib/sneeze/internals.ex
+++ b/lib/sneeze/internals.ex
@@ -86,5 +86,4 @@ defmodule Sneeze.Internal do
   def render_tag(tag, attributes) do
     [render_opening_tag(tag, attributes), render_closing_tag(tag)]
   end
-
 end

--- a/lib/sneeze/internals.ex
+++ b/lib/sneeze/internals.ex
@@ -3,29 +3,22 @@ defmodule Sneeze.Internal do
 
   Sneeze.Macros.define_tags_to_strings([
     :a,
+    :div,
     :span,
     :li,
-    :div,
-    :td,
     :br,
-    :ul,
-    :tr,
-    :link,
     :p,
-    :title,
-    :script,
-    :style,
-    :button,
-    :label,
-    :code,
-    :h1,
-    :h2,
-    :h3,
-    :h4,
-    :h5,
+    :link,
     :meta,
-    :body,
-    :head
+    :td,
+    :tr,
+    :ul,
+    :h3,
+    :h2,
+    :img,
+    :code,
+    :svg,
+    :button
   ])
 
   def void_tags() do

--- a/lib/sneeze/macros.ex
+++ b/lib/sneeze/macros.ex
@@ -1,0 +1,17 @@
+defmodule Sneeze.Macros do
+  @moduledoc false
+
+  defmacro define_tags_to_strings(tags) do
+    quote bind_quoted: [tags: tags] do
+      Enum.each(tags, fn tagname ->
+         as_str = to_string(tagname)
+
+         defp tag_to_string(unquote(tagname)) do
+           unquote(as_str)
+         end
+      end)
+
+      defp tag_to_string(unknown_tag), do: to_string(unknown_tag)
+    end
+  end
+end

--- a/lib/sneeze/macros.ex
+++ b/lib/sneeze/macros.ex
@@ -4,11 +4,11 @@ defmodule Sneeze.Macros do
   defmacro define_tags_to_strings(tags) do
     quote bind_quoted: [tags: tags] do
       Enum.each(tags, fn tagname ->
-         as_str = to_string(tagname)
+        as_str = to_string(tagname)
 
-         defp tag_to_string(unquote(tagname)) do
-           unquote(as_str)
-         end
+        defp tag_to_string(unquote(tagname)) do
+          unquote(as_str)
+        end
       end)
 
       defp tag_to_string(unknown_tag), do: to_string(unknown_tag)


### PR DESCRIPTION
I'm one of those people who likes to tinker with performance, so I got to tinkering a bit and this is what I came up with. If this type of thing is more complication than you feel is right for the project, no worries, I had fun doing it, I just wanted to offer it up for discussion/ideas just in case you felt it was something you wanted.

Anyway, the idea is this: in `sneeze`, users are going to be serializing the same of tags over and over again. Especially in large templates there can be hundreds or even thousands of the same tags. I did some crude evidence gathering by pulling down 20 wikipedia pages at random, parsing them, and aggregating the counts of the tags they contained, and sure enough there is *a ton* of tag repetition, especially on the heaviest hitters, like `a`, `li`, `span`, `div`, `td`, and `ul`. (Is wikipedia a representative sample? I let you be the judge!)

Rather than serialize the same atoms over and over again via `to_string`, we can precompute the string representation of those atoms, store them, and return that precomputed string via a pattern match, like so:

```elixir
defp tag_to_string(:a) do
  "a"
end
```

Returning the literal `"a"` has the effect of `"a"` becoming a compiled constant, and subsequent code that calls `tag_to_string(:a)` referencing that constant rather than have to stringify `:a` with each call (as per https://elixirforum.com/t/beam-optimization-for-functions-with-static-return-type/1868/2)

So I set up some `benchee` benchmarks, with the benchmarking script looking like this:

```elixir
layout = SneezeBench.layout("some title", "some content")

Benchee.run(
  %{
    "render/1" => fn -> Sneeze.render(layout) end,
    "render_iodata/1" => fn -> Sneeze.render_iodata(layout) end
  },
  time: 10,
  memory_time: 2
)
```

And the benchmarked template looking like this:

```elixir
defmodule SneezeBench do
  def layout(title, content) do
    [
      [:__@raw_html, "<!DOCTYPE html>"],
      [
        :head,
        [:meta, %{charset: "utf-8"}],
        [:meta, %{content: "IE=edge,chrome=1", "http-equiv": "X-UA-Compatible"}],
        [:title, [:__@raw_html, title]],
        [:meta, %{content: "width=device-width", name: "viewport"}],
        [:link, %{rel: "icon", href: "favicon-min.png", type: "image.png"}]
      ],
      [
        :body,
        [
          :div,
          %{class: "container"},
          [
            :div,
            %{class: "site"},
            [
              :div,
              %{class: "header"},
              [:h1, %{class: "title"}, [:a, %{href: "index.html"}, "Clark Kampfe"]],
              [:a, %{class: "extra", href: "about.html"}, "about"],
              " ",
              [:a, %{class: "extra", href: "resume.html"}, "resumé"]
            ],
            content,
            [
              :div,
              %{class: "footer"},
              [
                :div,
                %{class: "contact"},
                [
                  :p,
                  [:a, %{href: "https://github.com/ckampfe"}, "github"],
                  " ",
                  [:a, %{href: "https://twitter.com/ckampfe"}, "twitter"],
                  " ",
                  [:a, %{href: "/feed"}, "rss"]
                ]
              ]
            ]
          ]
        ]
      ]
    ]
  end
end
```

I ran each branch a few times each on OTP 26 and Elixir 1.15 with: `mix deps.clean --all && mix clean && mix deps.get && MIX_ENV=bench mix run bench.exs`.

Full disclosure: these benchmarks were on my laptop on battery power. I can try to run on mains power or a linux machine later if that's of interest.

Results on branch `main`:

```
Generated sneeze_bench app
Operating System: macOS
CPU Information: Apple M1 Max
Number of Available Cores: 10
Available memory: 64 GB
Elixir 1.15.0
Erlang 26.0.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 28 s

Benchmarking render/1 ...
Benchmarking render_iodata/1 ...

Name                      ips        average  deviation         median         99th %
render_iodata/1      204.69 K        4.89 μs   ±294.69%        4.13 μs        7.88 μs
render/1             140.47 K        7.12 μs   ±137.40%        6.54 μs       12.54 μs

Comparison:
render_iodata/1      204.69 K
render/1             140.47 K - 1.46x slower +2.23 μs

Memory usage statistics:

Name               Memory usage
render_iodata/1        11.60 KB
render/1               11.67 KB - 1.01x memory usage +0.0703 KB

**All measurements for memory usage were the same**
```

Results on branch `precompute-tag-strings` (this branch):

```
Generated sneeze_bench app
Operating System: macOS
CPU Information: Apple M1 Max
Number of Available Cores: 10
Available memory: 64 GB
Elixir 1.15.0
Erlang 26.0.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 28 s

Benchmarking render/1 ...
Benchmarking render_iodata/1 ...

Name                      ips        average  deviation         median         99th %
render_iodata/1      248.28 K        4.03 μs   ±441.95%        3.29 μs        6.17 μs
render/1             155.87 K        6.42 μs   ±229.69%        5.63 μs        9.58 μs

Comparison:
render_iodata/1      248.28 K
render/1             155.87 K - 1.59x slower +2.39 μs

Memory usage statistics:

Name               Memory usage
render_iodata/1        10.78 KB
render/1               10.80 KB - 1.00x memory usage +0.0156 KB

**All measurements for memory usage were the same**
```

resulting in these aggregate speedups:

| branch     | render/1 throughput increase | render_iodata/1 throughput increase |
| -----------   | -----------                          | ----------- |
| main             | 1.0x                                      | 1.0x |
| this branch  | ~1.11x                                   | ~1.21x |


Further/open questions:
- The sample template is very small and simple, so I am curious of the effect of this work on (much) larger templates. I think it's reasonable to guess that the results would be even further exaggerated for larger templates, but that's just a guess, I've only run with the above template.
- I based the tag_to_string function generation order on randomly gathered wikipedia pages. Is this tag order reasonable? Would more memoized tags result in a speedup? Are there too many as it is? I have no idea.

In any case thanks again for this library, I just wanted to share some tinkering I did in case you thought it was of use.
